### PR TITLE
feat(cli): improve tool error handling with LLM friendly output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `mcpli <server> <tool> --help` now prints each tool's full input JSON schema
+
 ## [1.2.0] - 2026-03-11
 
 ### Added

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -13,6 +13,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type toolCallEnvelope struct {
+	IsError bool `json:"isError"`
+}
+
 var rootCmd = &cobra.Command{
 	Use:   "mcpli",
 	Short: "MCP CLI - invoke MCP server tools from the command line",
@@ -118,14 +122,14 @@ func createToolCommand(serverName string, server *config.Server, tool config.Too
 				// Validate it's valid JSON
 				var test interface{}
 				if err := json.Unmarshal(arguments, &test); err != nil {
-					return fmt.Errorf("invalid JSON arguments: %w", err)
+					return failWithToolHelp(cmd, fmt.Errorf("invalid JSON arguments: %w", err))
 				}
 			}
 
 			// Resolve headers (including OAuth token if applicable)
 			headers, err := resolveHeaders(serverName, server)
 			if err != nil {
-				return err
+				return failWithToolHelp(cmd, err)
 			}
 
 			// Create client
@@ -134,7 +138,12 @@ func createToolCommand(serverName string, server *config.Server, tool config.Too
 			// Call the tool
 			result, err := client.CallTool(tool.Name, arguments)
 			if err != nil {
-				return err
+				return failWithToolHelp(cmd, err)
+			}
+
+			var envelope toolCallEnvelope
+			if err := json.Unmarshal(result, &envelope); err == nil && envelope.IsError {
+				return failWithToolHelp(cmd, fmt.Errorf("tool returned error response: %s", string(result)))
 			}
 
 			// Output raw JSON
@@ -158,6 +167,15 @@ func createToolCommand(serverName string, server *config.Server, tool config.Too
 	})
 
 	return cmd
+}
+
+func failWithToolHelp(cmd *cobra.Command, err error) error {
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
+	fmt.Println("Hint:")
+	_ = cmd.Help()
+	return err
 }
 
 // truncateDescription shortens a description for display

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -151,6 +152,8 @@ func createToolCommand(serverName string, server *config.Server, tool config.Too
 			fmt.Println(wrapped)
 			fmt.Println()
 		}
+
+		printToolInputSchema(tool)
 		fmt.Print(c.UsageString())
 	})
 
@@ -163,4 +166,26 @@ func truncateDescription(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-3] + "..."
+}
+
+func printToolInputSchema(tool config.Tool) {
+	if len(tool.InputSchema) == 0 {
+		return
+	}
+
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, tool.InputSchema); err != nil {
+		return
+	}
+
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, compact.Bytes(), "", "  "); err != nil {
+		return
+	}
+
+	fmt.Println("json-schema")
+	fmt.Println("```json")
+	fmt.Println(pretty.String())
+	fmt.Println("```")
+	fmt.Println()
 }


### PR DESCRIPTION
This commit adds structured error handling for tool calls and detects error responses from MCP servers. Also now by default  shows usage help if no argument is given to the tool.

Detailed Changes:
 - Implementation:
   - Added `toolCallEnvelope` struct to detect error responses from MCP servers.
   - Added `failWithToolHelp` function to display errors with tool usage hints.
   - Changed argument validation and tool execution to use `failWithToolHelp` for consistent error output.
   - Added check for server error responses in JSON envelope format.