### PR TITLE
Add vet and tests to CI, fix go install path

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,5 +17,11 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - name: Vet
+      run: go vet ./...
+
+    - name: Test
+      run: go test ./...
+
     - name: Build
       run: go build

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ brew install juanibiapina/taps/mcpli
 ### Go
 
 ```bash
-go install github.com/juanibiapina/mcpli/cmd/mcpli@latest
+go install github.com/juanibiapina/mcpli@latest
 ```
 
 ### Build from source


### PR DESCRIPTION
Two small fixes:

1. **CI now runs tests.** The build workflow only ran `go build`, skipping the test suites in `internal/mcp` and `internal/oauth`. Added `go vet ./...` and `go test ./...` steps before the build.

2. **Fixed `go install` path in README.** The install command pointed to `github.com/juanibiapina/mcpli/cmd/mcpli@latest`, but `main.go` is at the repo root (no `cmd/` directory). The correct path is `github.com/juanibiapina/mcpli@latest`. Goreleaser already builds from `.` correctly.